### PR TITLE
:building_construction: Remove placeholder outfit cards from DOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,22 +76,6 @@
       <section class="saved-outfits flex-column">
         <h2>Saved Outfits</h2>
         <div class="saved-outfits-container">
-          <div class="saved-outfit-card">
-            <p>Fancy</p>
-            <i class="fas fa-times"></i>
-          </div>
-          <div class="saved-outfit-card">
-            <p>A day out</p>
-            <i class="fas fa-times"></i>
-          </div>
-          <div class="saved-outfit-card">
-            <p>Beach time</p>
-            <i class="fas fa-times"></i>
-          </div>
-          <div class="saved-outfit-card">
-            <p>Mars prom</p>
-            <i class="fas fa-times"></i>
-          </div>
         </div>
       </section>
     </main>


### PR DESCRIPTION
In this PR (group programmed):

- we removed the placeholder cards that we initially used to style the right column section